### PR TITLE
Mailchimp audience migration

### DIFF
--- a/sponsor-mailing-list.md
+++ b/sponsor-mailing-list.md
@@ -13,7 +13,6 @@ layout: page
 		font: 14px Helvetica, Arial, sans-serif;
 		width: 600px;
 	}
-
 	/* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
 	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
 </style>
@@ -23,15 +22,13 @@ layout: page
 		width: auto;
 		margin-right: 10px;
 	}
-
 	#mergeRow-gdpr {
 		margin-top: 20px;
 	}
-
 	#mergeRow-gdpr fieldset label {
-		font-weight: normal;
+		margin-top: 0;
+		margin-left: 20px;
 	}
-
 	#mc-embedded-subscribe-form .mc_fieldset {
 		border: none;
 		min-height: 0px;
@@ -39,25 +36,20 @@ layout: page
 	}
 </style>
 <div id="mc_embed_signup">
+	<h3>Join our Sponsor Mailing List</h3>
 	<form
 		action="https://rocissa.us10.list-manage.com/subscribe/post?u=d959327774f7ee5c2ce9d4f38&amp;id=cdd40f2f79&amp;v_id=5396&amp;f_id=00735ae5f0"
 		method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
 		<div id="mc_embed_signup_scroll">
-			<h3>Join our Sponsor Mailing List</h3>
-
 			<p style="margin: 0 0 15px 0; font-size: 14px; line-height: 1.7em;">Thank you for considering supporting the Rochester Security Summit. To be contacted concerning future opportunities, please register for our mailing list by completing and submitting the form below.</p>
-
 			<p style="margin: 0 0 15px 0; font-size: 14px; line-height: 1.7em;">Since its inception in 2006, the Rochester Security Summit has grown and flourished, with many thanks to the invaluable contributions of our sponsors. Our sponsors play a vital role in our success, allowing us to provide high-quality events that foster knowledge exchange and professional growth and that create an impactful experience for everyone involved.</p>
-
 			<p style="margin: 0 0 15px 0; font-size: 14px; line-height: 1.7em;">To help ensure you receive time sensitive announcements, kindly consider the following:</p>
-
 			<ul style="margin: 0 0 15px 0; font-size: 14px; line-height: 1.7em;">
 				<li>Adding sponsorship@rochestersecurity.org to your company's whitelist.</li>
 				<li>Adding team or distribution list email addresses to our mailing list for convenience.</li>
 				<li>Adding multiple email addresses to our mailing list to ensure effective communication in the case of staffing changes or OOO scenarios.</li>
 				<li>We use mailchimp to communicate with and manage our mailing list.</li>
 			</ul>
-
 			<div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
 			<div class="mc-field-group">
 				<label for="mce-EMAIL">Email Address <span class="asterisk">*</span>
@@ -86,6 +78,7 @@ layout: page
 							<span>Email</span>
 						</label>
 					</fieldset>
+					<p></p>
 					<p>You can unsubscribe at any time by clicking the link in the footer of our emails. For information about our
 						privacy practices, please visit our website.</p>
 				</div>

--- a/sponsor-mailing-list.md
+++ b/sponsor-mailing-list.md
@@ -4,65 +4,109 @@ layout: page
 ---
 
 <!-- Begin Mailchimp Signup Form -->
-<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+<link href="//cdn-images.mailchimp.com/embedcode/classic-061523.css" rel="stylesheet" type="text/css">
 <style type="text/css">
-	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif;  width:600px;}
+	#mc_embed_signup {
+		background: #fff;
+		false;
+		clear: left;
+		font: 14px Helvetica, Arial, sans-serif;
+		width: 600px;
+	}
+
 	/* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
 	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
 </style>
+<style type="text/css">
+	#mc-embedded-subscribe-form input[type=checkbox] {
+		display: inline;
+		width: auto;
+		margin-right: 10px;
+	}
+
+	#mergeRow-gdpr {
+		margin-top: 20px;
+	}
+
+	#mergeRow-gdpr fieldset label {
+		font-weight: normal;
+	}
+
+	#mc-embedded-subscribe-form .mc_fieldset {
+		border: none;
+		min-height: 0px;
+		padding-bottom: 0px;
+	}
+</style>
 <div id="mc_embed_signup">
-<form action="https://rocissa.us10.list-manage.com/subscribe/post?u=d959327774f7ee5c2ce9d4f38&amp;id=ea5d0e85ab" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<h3>Join our Sponsor Mailing List</h3>
+	<form
+		action="https://rocissa.us10.list-manage.com/subscribe/post?u=d959327774f7ee5c2ce9d4f38&amp;id=cdd40f2f79&amp;v_id=5396&amp;f_id=00735ae5f0"
+		method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
+		<div id="mc_embed_signup_scroll">
+			<h3>Join our Sponsor Mailing List</h3>
 
-<p style="margin: 0 0 15px 0; font-size: 14px; line-height: 1.7em;">Thank you for considering supporting the Rochester Security Summit. To be contacted concerning future opportunities, please register for our mailing list by completing and submitting the form below.</p>
+			<p style="margin: 0 0 15px 0; font-size: 14px; line-height: 1.7em;">Thank you for considering supporting the Rochester Security Summit. To be contacted concerning future opportunities, please register for our mailing list by completing and submitting the form below.</p>
 
-<p style="margin: 0 0 15px 0; font-size: 14px; line-height: 1.7em;">Since its inception in 2006, the Rochester Security Summit has grown and flourished, with many thanks to the invaluable contributions of our sponsors. Our sponsors play a vital role in our success, allowing us to provide high-quality events that foster knowledge exchange and professional growth and that create an impactful experience for everyone involved.</p>
+			<p style="margin: 0 0 15px 0; font-size: 14px; line-height: 1.7em;">Since its inception in 2006, the Rochester Security Summit has grown and flourished, with many thanks to the invaluable contributions of our sponsors. Our sponsors play a vital role in our success, allowing us to provide high-quality events that foster knowledge exchange and professional growth and that create an impactful experience for everyone involved.</p>
 
-<p style="margin: 0 0 15px 0; font-size: 14px; line-height: 1.7em;">To help ensure you receive time sensitive announcements, kindly consider the following:</p>
+			<p style="margin: 0 0 15px 0; font-size: 14px; line-height: 1.7em;">To help ensure you receive time sensitive announcements, kindly consider the following:</p>
 
-<ul style="margin: 0 0 15px 0; font-size: 14px; line-height: 1.7em;">
-	<li>Adding sponsorship@rochestersecurity.org to your company's whitelist.</li>
-    <li>Adding team or distribution list email addresses to our mailing list for convenience.</li>
-    <li>Adding multiple email addresses to our mailing list to ensure effective communication in the case of staffing changes or OOO scenarios.</li>
-    <li>We use mailchimp to communicate with and manage our mailing list.</li>
-</ul>
+			<ul style="margin: 0 0 15px 0; font-size: 14px; line-height: 1.7em;">
+				<li>Adding sponsorship@rochestersecurity.org to your company's whitelist.</li>
+				<li>Adding team or distribution list email addresses to our mailing list for convenience.</li>
+				<li>Adding multiple email addresses to our mailing list to ensure effective communication in the case of staffing changes or OOO scenarios.</li>
+				<li>We use mailchimp to communicate with and manage our mailing list.</li>
+			</ul>
 
-<div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
-<div class="mc-field-group">
-	<label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
-</label>
-	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+			<div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
+			<div class="mc-field-group">
+				<label for="mce-EMAIL">Email Address <span class="asterisk">*</span>
+				</label>
+				<input type="email" name="EMAIL" class="required email" id="mce-EMAIL" required="" value="">
+			</div>
+			<div class="mc-field-group">
+				<label for="mce-FNAME">First Name </label>
+				<input type="text" name="FNAME" class=" text" id="mce-FNAME" value="">
+			</div>
+			<div class="mc-field-group">
+				<label for="mce-LNAME">Last Name </label>
+				<input type="text" name="LNAME" class=" text" id="mce-LNAME" value="">
+			</div>
+			<div class="mc-field-group">
+				<label for="mce-MMERGE5">Company </label>
+				<input type="text" name="MMERGE5" class=" text" id="mce-MMERGE5" value="">
+			</div>
+			<div id="mergeRow-gdpr" class="mergeRow gdpr-mergeRow content__gdprBlock mc-field-group">
+				<div class="content__gdpr">
+					<label>Marketing Permissions</label>
+					<p>Please select all the ways you would like to hear from :</p>
+					<fieldset class="mc_fieldset gdprRequired mc-field-group" name="interestgroup_field">
+						<label class="checkbox subfield" for="gdpr62128"><input type="checkbox" id="gdpr_62128" name="gdpr[62128]"
+								class="gdpr" value="Y">
+							<span>Email</span>
+						</label>
+					</fieldset>
+					<p>You can unsubscribe at any time by clicking the link in the footer of our emails. For information about our
+						privacy practices, please visit our website.</p>
+				</div>
+				<div class="content__gdprLegal">
+					<p>We use Mailchimp as our marketing platform. By clicking below to subscribe, you acknowledge that your
+						information will be transferred to Mailchimp for processing. <a
+							href="https://mailchimp.com/legal/terms">Learn more</a> about Mailchimp's privacy practices.</p>
+				</div>
+			</div>
+			<div id="mce-responses" class="clear">
+				<div class="response" id="mce-error-response" style="display: none;"></div>
+				<div class="response" id="mce-success-response" style="display: none;"></div>
+			</div>
+			<div aria-hidden="true" style="position: absolute; left: -5000px;"><input type="text"
+					name="b_d959327774f7ee5c2ce9d4f38_cdd40f2f79" tabindex="-1" value=""></div>
+			<div class="clear"><input type="submit" name="subscribe" id="mc-embedded-subscribe" class="button"
+					value="Subscribe"></div>
+		</div>
+	</form>
 </div>
-<div class="mc-field-group">
-	<label for="mce-FNAME">First Name  <span class="asterisk">*</span></label>
-	<input type="text" value="" name="FNAME" class="required" id="mce-FNAME">
-</div>
-<div class="mc-field-group">
-	<label for="mce-LNAME">Last Name  <span class="asterisk">*</span></label>
-	<input type="text" value="" name="LNAME" class="required" id="mce-LNAME">
-</div>
-<div class="mc-field-group">
-	<label for="mce-MMERGE5">Company Name  <span class="asterisk">*</span></label>
-	<input type="text" value="" name="MMERGE5" class="required" id="mce-MMERGE5">
-</div>
-<div class="mc-field-group input-group">
-    <strong>Also email me about:</strong>
-    <ul><li style="display: none"><input type="checkbox" value="1" name="group[364752][1]" id="mce-group[364752]-364752-0" checked><label for="mce-group[364752]-364752-0">Rochester Security Summit</label></li>
-<li><input type="checkbox" value="2" name="group[364752][2]" id="mce-group[364752]-364752-1"><label for="mce-group[364752]-364752-1">ISSA Rochester Chapter</label></li>
-<li><input type="checkbox" value="4" name="group[364752][4]" id="mce-group[364752]-364752-2"><label for="mce-group[364752]-364752-2">Other Local Events</label></li>
-<li><input type="checkbox" value="8" name="group[364752][8]" id="mce-group[364752]-364752-3"><label for="mce-group[364752]-364752-3">Job Listings</label></li>
-<li style="display: none"><input type="checkbox" value="16" name="group[364752][16]" id="mce-group[364752]-364752-4" checked><label for="mce-group[364752]-364752-4">Sponsorship Opportunities</label></li>
-</ul>
-</div>
-	<div id="mce-responses" class="clearfix">
-		<div class="response" id="mce-error-response" style="display:none">An error occurred</div>
-		<div class="response" id="mce-success-response" style="display:none">Thank you for subscribing!</div>
-	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_d959327774f7ee5c2ce9d4f38_ea5d0e85ab" tabindex="-1" value=""></div>
-    <div class="clearfix"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
-<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='MMERGE5';ftypes[5]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+<script type="text/javascript" src="//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js"></script>
+<script
+	type="text/javascript">(function ($) { window.fnames = new Array(); window.ftypes = new Array(); fnames[0] = 'EMAIL'; ftypes[0] = 'email'; fnames[1] = 'FNAME'; ftypes[1] = 'text'; fnames[2] = 'LNAME'; ftypes[2] = 'text'; fnames[5] = 'MMERGE5'; ftypes[5] = 'text'; fnames[3] = 'ADDRESS'; ftypes[3] = 'address'; fnames[4] = 'PHONE'; ftypes[4] = 'phone'; fnames[6] = 'MMERGE6'; ftypes[6] = 'text'; fnames[7] = 'MMERGE7'; ftypes[7] = 'text'; }(jQuery)); var $mcj = jQuery.noConflict(true);</script>
 <!--End mc_embed_signup-->


### PR DESCRIPTION
We're now using a new audience in Mailchimp; specifically to separate RocISSA and RSS list management. This PR will ensure new sponsor sign-ups go to the right list.