### PR TITLE
closed CFP and updated about us

### DIFF
--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -108,14 +108,14 @@ sponsors_show_talks: true
 # speaking messaging
 speaking_next_year: false
 speaking_cfp_not_yet_open: false
-speaking_cfp_open: true
-speaking_cfp_closed: false
+speaking_cfp_open: false
+speaking_cfp_closed: true
 speaking_show_key_dates: true
 speaking_page_url: https://www.rochestersecurity.org/speaking/
 
 # speaking key dates
 speaking_cfp_opens: 2025-04-14
-speaking_proposals_due: 2025-06-16
+speaking_proposals_due: 2025-06-21
 speaking_committee_responses: 2025-07-31
 speaking_materials_due: 2025-08-22
 speaking_notification_of_slide_changes: 2025-09-12

--- a/about-us.md
+++ b/about-us.md
@@ -14,13 +14,17 @@ layout: page
 <h2>Planning Committees</h2>
 <div class="col-md-6">
 <div class="about-us">
-<h3>2024 General Planning Committee</h3>
+<h3>2025 General Planning Committee</h3>
 
 * **Summit Chair** - John King<sup>*</sup>, Flexion Inc. (ISSA, InfraGard, OWASP)
 
 * **Summit Coordinator** - Mary Beth King, Rochester Security Summit
 
+* Dennis Allen
+
 * Shaquille Barnes, ESL (ISSA, InfraGard)
+
+* Hannah Chang
 
 * Mark Christman, Microsoft
 
@@ -36,6 +40,8 @@ layout: page
 
 * Keith Hunt<sup>*</sup>, University of Rochester (ISSA, OWASP)
 
+* Lilian Isacks
+
 * Heather Klem, Dox Electronics (ISSA)
 
 * Phil LaGraff, PC LaGraff Consulting (ISSA, Infragard)
@@ -46,15 +52,13 @@ layout: page
 
 * Bruce Nelson, Eastman Kodak (retired)
 
-* Gary Pecor, Xerox (retired)
-
 * Joe Pierson<sup>*</sup>, Equitable (ISSA, Infragard)
 
 * Jason Pitoniak<sup>*</sup>, Rochester Institute of Technology (ISSA, OWASP)
 
 * Rose Rozeski<sup>*</sup>, Independent Health (ISSA)
 
-* Rich Savacool<sup>*</sup>, Nixon Peabody, LLP (ISSA)
+* Rich Savacool, Nixon Peabody, LLP (ISSA)
 
 * Aaron Schanz, Constellation Brands
 
@@ -62,11 +66,9 @@ layout: page
 
 * Richard Smith, Security Risk Advisors (ISSA)
 
-* David Warden<sup>*</sup>, SUNY Geneseo (ISSA)
+* Dave Warden<sup>*</sup>, SUNY Geneseo (ISSA)
 
 * Edward Woodfield, PayQuicker (ISSA, InfraGard)
-
-* Jason Woodson, Major League Baseball
 
 </div>
 <div class="about-us">
@@ -88,13 +90,17 @@ layout: page
 <div class="about-us">
 <h3>Speaker Committee</h3>
 
-* **Chair** - Richard Smith
+* **Chair** - Deb Shymalov
+
+* Dennis Allen
+
+* Ralph Durkee
 
 * Barry Hofecker
 
-* Rose Rozeski
+* Lilian Isacks
 
-* Deb Shymalov
+* Rose Rozeski
 
 * Dave Warden
 
@@ -106,11 +112,9 @@ layout: page
 
 * Shaq Barnes
 
-* Tom Hasman
+* Tim Minsterman
 
 * Aaron Schanz
-
-* Tim Minsterman
 
 </div>
 <div class="about-us">
@@ -122,25 +126,21 @@ layout: page
 
 * **A/V Lead:** Joe Pierson
 
-* **A/V:** Heather Klem
-
 * **Photography:** Bruce Nelson
 
 </div>
 <div class="about-us">
-<h3>Marketing / Communications Committee</h3>
+<h3>Web Development</h3>
 
-* **Web Lead:** Jason Pitoniak
+* **Lead** - Jason Pitoniak
 
-* **Web:** Edward Woodfield
-
-* **Social Media:** Jason Woodson
+* Edward Woodfield
 
 </div>
 <div class="about-us">
-<h3>Finance Committee</h3>
+<h3>Treasurer</h3>
 
-* **Chair** - Dave Warden
+* Paul Goyette
 
 </div>
 </div>

--- a/speaking.md
+++ b/speaking.md
@@ -70,9 +70,13 @@ Thank you,
 Contact: <{{ site.speaking_contact_email }}> for more information | Website: <{{ site.baseurl }}>
 
 {% endif %}
+<div class="attention">
 {% if site.speaking_cfp_closed %}
-<h2 class="center">Speaker submissions for RSS:{{ site.current_year }} have closed</h2>
+<h2 class="center">Call for Presentations for RSS:{{ site.current_year }} has closed</h2>
+<p>Thank you to everyone who submitted a proposal! The submission window is now closed.</p>
+<p>We appreciate your interest and support — proposal review is underway and submitters will be notified by {{ site.speaking_committee_responses | localtime | date: "%B %e" }}</p>
 {% endif %}
+</div>
 
 {% if site.speaking_show_key_dates %}
 <hr>


### PR DESCRIPTION
Changed the speaker page to close the CFP, with some new text (includes site.yaml changes).

Updated the About Us page to be accurate for 2025. Still missing some company names for some people.