### PR TITLE
fixed FAQ text and about us page

### DIFF
--- a/about-us.md
+++ b/about-us.md
@@ -31,7 +31,7 @@ layout: page
 
 * Hannah Chang, Nixon Peabody, LLP
 
-* Mark Christman, Microsoft
+* Mark Christman
 
 * Ralph Durkee, Durkee Consulting, Inc. (ISSA, OWASP)
 

--- a/css/local.css
+++ b/css/local.css
@@ -92,12 +92,12 @@ section#slider {
 	height: auto;
 }
 
-.faq li {
+.faq blockquote {
 	font-weight: normal;
 	font-size: 100%;
 }
 
-.faq ul {
+.faq li {
 	font-weight: normal;
 	font-size: 100%;
 }

--- a/volunteering.md
+++ b/volunteering.md
@@ -2,6 +2,7 @@
 title:
 layout: page
 ---
+
 <div class="faq col-md-12">
 <div class="full-logo-image"> 
 <a href="/">


### PR DESCRIPTION
Fixed CSS for FAQ text.
Removed Mark's company name from the about us page.