### PR TITLE
CFP-color-change

### DIFF
--- a/css/local.css
+++ b/css/local.css
@@ -312,6 +312,41 @@ section#slider {
 	text-align: center;
 }
 
+.less-attention {
+	background-color: moccasin;
+	margin: 1rem 3rem;
+	padding: 1rem;
+	text-align: center;
+}
+
+.less-attention h1 {
+	text-transform: uppercase;
+	font-weight: bold;
+	font-size: 3em;
+	text-align: center;
+}
+
+.less-attention h2 {
+	font-weight: bold;
+	font-size: 2em;
+	font-variant: small-caps;
+	text-align: center;
+}
+
+.less-attention h3 {
+	font-weight: bold;
+	font-size: 1.3em;
+	font-variant: small-caps;
+	text-align: center;
+}
+
+.less-attention h4 {
+	font-weight: normal;
+	font-size: 1.1em;
+	font-style: italic;
+	text-align: center;
+}
+
 .tickets {
 	width: auto;
 }

--- a/index.md
+++ b/index.md
@@ -80,7 +80,7 @@ layout: page
 	{%- endif -%}
 	{%- endif -%}
 	{%- if site.speaking_cfp_open == true -%}
-	<section id="attention" class="attention">
+	<section id="less-attention" class="less-attention">
 		<div>
 		<h1>The Call For Presentations is now open!</h1>
 		<h3>Check out the Speaking page to submit a proposal for the Rochester Security Summit {{ site.current_year }}</h3>


### PR DESCRIPTION
Made CFP note on the home page a less bright color so the keynotes stand out more, but the CFP is still a bit highlighted.